### PR TITLE
Add PDF query script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# PDF Question Tool
+
+This project provides a simple script to query the OpenAI API about the
+contents of a PDF file.
+
+## Setup
+
+1. Install dependencies (requires internet access):
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Set the `OPENAI_API_KEY` environment variable to your OpenAI API key.
+
+## Usage
+
+Run the script with the path to the PDF file and your question:
+
+```bash
+python ask_open_ai.py -f "file.pdf" "Summarize the first two pages"
+```
+
+The script logs its progress and prints the assistant's answer.

--- a/ask_open_ai.py
+++ b/ask_open_ai.py
@@ -1,0 +1,51 @@
+import argparse
+import logging
+import os
+
+import openai
+from pdfminer.high_level import extract_text
+
+
+def extract_pdf_text(pdf_path: str) -> str:
+    """Extract all text from a PDF file."""
+    with open(pdf_path, "rb") as fp:
+        return extract_text(fp)
+
+
+def ask_openai_about_pdf(pdf_path: str, question: str) -> str:
+    """Send the text of a PDF and a question to OpenAI and return the response."""
+    logging.info("Extracting text from %s", pdf_path)
+    text = extract_pdf_text(pdf_path)
+
+    logging.info("Sending request to OpenAI API")
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY environment variable not set")
+    openai.api_key = api_key
+
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {
+            "role": "user",
+            "content": f"{question}\n\nDocument text:\n{text}",
+        },
+    ]
+
+    response = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=messages)
+    logging.info("Received response from OpenAI")
+    return response["choices"][0]["message"]["content"]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Ask OpenAI a question about a PDF")
+    parser.add_argument("-f", "--file", required=True, help="Path to PDF file")
+    parser.add_argument("question", help="Question to ask about the PDF")
+    args = parser.parse_args()
+
+    answer = ask_openai_about_pdf(args.file, args.question)
+    print(answer)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+openai
+pdfminer.six


### PR DESCRIPTION
## Summary
- add a simple script `ask_open_ai.py` to ask OpenAI about a PDF
- document how to run the script
- list required dependencies

## Testing
- `python3 -m py_compile ask_open_ai.py`
- `pip3 install openai pdfminer.six` *(fails: cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6882637ec92083228b12775b4e09483b